### PR TITLE
修复了多个片段的命名在一些软件中无法识别的问题

### DIFF
--- a/crates/javcap/src/payload.rs
+++ b/crates/javcap/src/payload.rs
@@ -108,7 +108,7 @@ impl Payload {
             let filename = if *idx == 0 {
                 format!("{}.{}", name, video.ext())
             } else {
-                format!("{}-{}.{}", name, idx, video.ext())
+                format!("{}-CD{}.{}", name, idx, video.ext())
             };
             let out = path.join(&filename);
             if out.exists() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Video files now use an updated naming convention: non-primary videos include a "CD" label before their sequence number, offering clearer organization and easier identification for users managing multimedia content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->