### PR TITLE
将porny的匹配规则从包含改为相等

### DIFF
--- a/crates/spider/src/porny.rs
+++ b/crates/spider/src/porny.rs
@@ -120,7 +120,7 @@ impl Porny {
             item.select(&self.selectors.title)
                 .next()
                 .map(|title| title.text().collect::<String>())
-                .map(|title| title.contains(&name))
+                .map(|title| title == name)
                 .unwrap_or(false)
         }) else {
             bail!("item not found");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search functionality to require exact title matches instead of partial matches when searching for videos. This change may affect which items appear in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->